### PR TITLE
Creating console.log replaces the console object

### DIFF
--- a/js/core/_jo.js
+++ b/js/core/_jo.js
@@ -117,8 +117,10 @@ if (typeof HTMLElement === 'undefined')
 	HTMLElement = Object;
 
 // no console.log? sad...
-if (typeof console === 'undefined' || typeof console.log !== 'function')
-	console = {log: function(msg) { }};
+if (typeof console === 'undefined')
+	console = { };
+if (typeof console.log !== 'function')
+	console.log = function(msg) { };
 
 // just a place to hang our hat
 jo = {

--- a/js/jo.js
+++ b/js/jo.js
@@ -150,8 +150,10 @@ if (typeof HTMLElement === 'undefined')
 	HTMLElement = Object;
 
 // no console.log? sad...
-if (typeof console === 'undefined' || typeof console.log !== 'function')
-	console = {log: function(msg) { }};
+if (typeof console === 'undefined')
+	console = { };
+if (typeof console.log !== 'function')
+	console.log = function(msg) { };
 
 // just a place to hang our hat
 jo = {

--- a/js/jo_min.js
+++ b/js/jo_min.js
@@ -4,8 +4,9 @@ console.log(strings.join(" "));};Function.prototype.extend=function(superclass,p
 this.prototype[i]=proto[i];}};if(typeof Function.prototype.bind==='undefined'){Function.prototype.bind=function(context){var self=this;function callbind(){return self.apply(context,arguments);}
 return callbind;};}
 if(typeof HTMLElement==='undefined')
-HTMLElement=Object;if(typeof console==='undefined'||typeof console.log!=='function')
-console={log:function(msg){}};jo={platform:"webkit",version:"0.4.2",useragent:['ipad','iphone','playbook','webos','hpwos','bada','android','opera','chrome','safari','mozilla','gecko','explorer'],debug:false,setDebug:function(state){this.debug=state;},flag:{stopback:false},load:function(call,context){joDOM.enable();this.loadEvent=new joSubject(this);this.unloadEvent=new joSubject(this);document.body.onMouseDown=function(e){e.preventDefault();};document.body.onDragStart=function(e){e.preventDefault();};if(typeof navigator=='object'&&navigator.userAgent){var agent=navigator.userAgent.toLowerCase();for(var i=0;i<this.useragent.length;i++){if(agent.indexOf(this.useragent[i])>=0){this.platform=this.useragent[i];break;}}}
+HTMLElement=Object;if(typeof console==='undefined')
+console={};if(typeof console.log!=='function')
+console.log=function(msg){};jo={platform:"webkit",version:"0.4.2",useragent:['ipad','iphone','playbook','webos','hpwos','bada','android','opera','chrome','safari','mozilla','gecko','explorer'],debug:false,setDebug:function(state){this.debug=state;},flag:{stopback:false},load:function(call,context){joDOM.enable();this.loadEvent=new joSubject(this);this.unloadEvent=new joSubject(this);document.body.onMouseDown=function(e){e.preventDefault();};document.body.onDragStart=function(e){e.preventDefault();};if(typeof navigator=='object'&&navigator.userAgent){var agent=navigator.userAgent.toLowerCase();for(var i=0;i<this.useragent.length;i++){if(agent.indexOf(this.useragent[i])>=0){this.platform=this.useragent[i];break;}}}
 if(joEvent){var o=document.createElement('div');var test=("ontouchstart"in o);if(!test){o.setAttribute("ontouchstart",'return;');test=(typeof o.ontouchstart==='function');}
 joEvent.touchy=test;o=null;}
 if(joGesture)


### PR DESCRIPTION
I was looking at the jo source, and it seemed to me that the code for creating the dummy console.log wasn't safe in the case of a broken environment that has a console object, but doesn't have a log property. In that case, it would replace the entire console object, which probably isn't the desired outcome.
